### PR TITLE
Visibility modifiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.0'
+        classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12+'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 22 10:53:35 PDT 2014
+#Tue Jan 06 22:16:06 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/replay-android-demo/src/main/AndroidManifest.xml
+++ b/replay-android-demo/src/main/AndroidManifest.xml
@@ -17,10 +17,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name="io.replay.framework.demo.MainActivity2"
-            android:label="@string/title_activity_main_activity2" >
-        </activity>
     </application>
 
 </manifest>

--- a/replay-android/build.gradle
+++ b/replay-android/build.gradle
@@ -6,7 +6,6 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        applicationId "io.replay.framework"
         minSdkVersion rootProject.ext.minSDKVersion
         targetSdkVersion rootProject.ext.targetSDKVersion
         versionCode rootProject.ext.versionCode

--- a/replay-android/src/main/java/io/replay/framework/ReplayActivity.java
+++ b/replay-android/src/main/java/io/replay/framework/ReplayActivity.java
@@ -28,25 +28,25 @@ public class ReplayActivity extends Activity {
     }
 
     @Override
-    public void onStart() {
+    protected void onStart() {
         super.onStart();
         ReplayIO.onActivityStart(this);
     }
 
     @Override
-    public void onResume() {
+    protected void onResume() {
         super.onResume();
         ReplayIO.onActivityResume(this);
     }
 
     @Override
-    public void onPause() {
+    protected void onPause() {
         ReplayIO.onActivityPause(this);
         super.onPause();
     }
 
     @Override
-    public void onStop() {
+    protected void onStop() {
         ReplayIO.onActivityStop(this);
         super.onStop();
     }


### PR DESCRIPTION
This PR includes changes to the Gradle Plugin version required to import and run the project in Android Studio 1.0.+, and changes to the ReplayActivity visibility modifiers.

I am proposing that the visibility modifiers be set to `protected` instead of `public` since the visibility modifiers for these `Activity` methods are `protected` by default. The change results in less interference with existing third-party code which may override the `protected` methods already.

When a developer tries to use ReplayActivity with existing sources they will get the following error:
```
Error:(75, 20) error: onResume() in MainActivity cannot override onResume() in ReplayActivity
attempting to assign weaker access privileges; was public
```
The error is then fixed by changing existing visibility to public in pre-existing code for all the related lifecycle methods that ReplayActivity has defined and for all activity extending ReplayActivity.

If this is accepted, the example code on the Replay.io site will also need to be changed.

Change Originally Suggested in Commit Comment:
https://github.com/Originate/replay-android/commit/95734f9f8eb2560bdb229f63501e6128d3672089#commitcomment-9102947
